### PR TITLE
Clean-up development dependencies and add "pry"

### DIFF
--- a/pluckeroid.gemspec
+++ b/pluckeroid.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord', '~> 3.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_development_dependency 'pry', '~> 0.9'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 2.6'
   spec.add_development_dependency 'sqlite3', '~> 1.3.7'
-  spec.add_development_dependency 'rspec',   '~> 2.6'
-  spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
- Loosen version requirement for "bundler"
- Be slightly more explicit about the desired "rake" version
- Add "pry" gem (useful for debugging/iterative development)
