### PR TITLE
Ability to alias "pluck_attributes" column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Person.pluck(:id, :name)
 
 Person.pluck_attributes(:id, :name)
 # => [{ 'id' => 1, 'name' => 'Obi-Wan' }, { 'id' => 2, 'name' => 'Luke' }]
+
+Person.pluck_attributes(:id, :name, :column_mappings => { 'id' => 'person_id' })
+# => [{ 'person_id' => 1, 'name' => 'Obi-Wan' }, { 'person_id' => 2, 'name' => 'Luke' }]
 ```
 
 ## Contributing

--- a/lib/pluckeroid/active_record/relation.rb
+++ b/lib/pluckeroid/active_record/relation.rb
@@ -93,7 +93,7 @@ module Pluckeroid
       end
 
       def extract_column_mappings(options)
-        (options[:column_mappings] || {}).with_indifferent_access
+        (options[:column_mappings] || {}).stringify_keys
       end
     end
   end

--- a/spec/pluckeroid/pluckeroid_spec.rb
+++ b/spec/pluckeroid/pluckeroid_spec.rb
@@ -28,6 +28,16 @@ describe Pluckeroid do
     it { should raise_error }
   end
 
+  context 'without column mappings' do
+    subject { Person.pluck_attributes('id') }
+    it { should eq (1..100).map {|n| {'id' => n}} }
+  end
+
+  context 'with column mappings' do
+    subject { Person.pluck_attributes('id', :column_mappings => {'id' => 'person_id'}) }
+    it { should eq (1..100).map {|n| {'person_id' => n}} }
+  end
+
   context 'with multiple values' do
     subject { Person.values_of :id, :last_name }
     it { should eq (1..100).map {|n| [n, "Number#{n}"]} }


### PR DESCRIPTION
This new feature adds the ability to alias the keys (column names) of
the results returned from "pluck_attributes" (while still maintaining
the proper type-casts).
- Add tests for "pluck_attributes" to cover existing functionality
- Add tests for "pluck_attributes" to cover new alias[ing] functionality
- Minor clean-up/refactoring
- Update README.md
